### PR TITLE
Add context option on harddrives to toggle collected status

### DIFF
--- a/src/BaseLayout.js
+++ b/src/BaseLayout.js
@@ -4909,6 +4909,28 @@ export default class BaseLayout
         return html;
     }
 
+    toggleHardDriveHasBeenOpened(collectible)
+    {
+        let marker = collectible.relatedTarget
+        let currentObject = this.saveGameParser.getTargetObject(marker.options.pathName);
+        let hasBeenOpened = this.getObjectProperty(currentObject, 'mHasBeenOpened', 0)
+        if(hasBeenOpened == 0)
+        {
+            this.setObjectProperty(currentObject, 'mHasBeenOpened', 1, 'BoolProperty')
+        }
+        else
+        {
+            this.deleteObjectProperty(currentObject, 'mHasBeenOpened')
+        }
+        
+        let updatedOpacity = 1;
+        if(hasBeenOpened === 0)
+        {
+            updatedOpacity = window.SCIM.collectedOpacity;
+        }
+        marker.setOpacity(updatedOpacity);
+    }
+
     updateObjectProductionPausedStatus(marker)
     {
         let currentObject       = this.saveGameParser.getTargetObject(marker.relatedTarget.options.pathName);

--- a/src/BaseLayout/ContextMenu.js
+++ b/src/BaseLayout/ContextMenu.js
@@ -99,6 +99,10 @@ export default class BaseLayout_ContextMenu
                         text: 'Teleport player',
                         callback: this.baseLayout.teleportPlayer.bind(this.baseLayout)
                     });
+                    contextMenu.push({
+                        text: 'Toggle explored',
+                        callback: this.baseLayout.toggleHardDriveHasBeenOpened.bind(this.baseLayout)
+                    });
                     break;
             }
 


### PR DESCRIPTION
When you right click on a harddrive, there's a new option that toggles, whether the harddrive has been collected or not.