### PR TITLE
feat: add an way to round object's translation to nearest given value

### DIFF
--- a/src/Modal/Selection.js
+++ b/src/Modal/Selection.js
@@ -11,6 +11,7 @@ import Selection_Offset                         from '../Selection/Offset.js';
 import Selection_Rotate                         from '../Selection/Rotate.js';
 import Selection_Delete                         from '../Selection/Delete.js';
 import Selection_Copy                           from '../Selection/Copy.js';
+import Selection_RoundTranslation               from '../Selection/RoundTranslation';
 
 import Spawn_Fill                               from '../Spawn/Fill.js';
 
@@ -261,6 +262,7 @@ export default class Modal_Selection
 
                 inputOptions.push({group: 'Positioning', text: 'Offset selected items position', value: 'offset'});
                 inputOptions.push({group: 'Positioning', text: 'Rotate selected items position', value: 'rotate'});
+                inputOptions.push({group: 'Positioning', text: 'Round selected items\' positions to nearest N meters', value: 'roundtranslation'});
 
                 inputOptions.push({group: 'Blueprints', text: 'Add "Foundation 8m x 2m" helpers on selection boundaries', value: 'helpers'});
                 inputOptions.push({group: 'Blueprints', text: 'Copy selected items', value: 'copy'});
@@ -504,6 +506,67 @@ export default class Modal_Selection
                     baseLayout  : baseLayout,
                     markers     : markers,
                     angle       : form.angle
+                });
+            }
+        });
+    }
+
+    static callbackRoundtranslation(baseLayout, markers)
+    {
+        BaseLayout_Modal.form({
+            title       : 'You have selected ' + markers.length + ' items',
+            message     : 'Step Size is the number to round to. The offset will be applied after the rounding.<br /><strong>NOTE:</strong> A foundation is 800 wide.',
+            onEscape    : function(){
+                Modal_Selection.cancel.call(null, baseLayout);
+            },
+            container   : '#leafletMap',
+            inputs      : [{
+                label       : 'Step Size',
+                name        : 'step',
+                inputType   : 'number',
+                value       : 25,
+                min         : Number.EPSILON // must be greater than 0
+            },
+            {
+                label       : 'Offset',
+                name        : 'offset',
+                inputType   : 'number',
+                value       : 0,
+                min         : 0
+            },
+            {
+                label       : 'Apply to X axis',
+                name        : 'roundX',
+                inputType   : 'toggle',
+                value       : 1
+            },
+            {
+                label       : 'Apply to Y axis',
+                name        : 'roundY',
+                inputType   : 'toggle',
+                value       : 1
+            },
+            {
+                label       : 'Apply to Z axis',
+                name        : 'roundZ',
+                inputType   : 'toggle',
+                value       : 1
+            }],
+            callback: function(form)
+            {
+                if(form === null || form.offsetX === null || form.offsetY === null || form.offsetZ === null)
+                {
+                    return;
+                }
+
+                return new Selection_RoundTranslation({
+                    baseLayout  : baseLayout,
+                    markers     : markers,
+                    step        : form.step,
+                    offset      : form.offset,
+                    roundX      : form.roundX,
+                    roundY      : form.roundY,
+                    roundZ      : form.roundZ,
                 });
             }
         });

--- a/src/Selection/RoundTranslation.js
+++ b/src/Selection/RoundTranslation.js
@@ -1,0 +1,154 @@
+/* global gtag */
+import Modal_Selection from '../Modal/Selection.js';
+
+export default class Selection_RoundTranslation
+{
+    constructor(options)
+    {
+        this.baseLayout             = options.baseLayout;
+        this.markers                = options.markers;
+
+        this.step                   = Number.parseFloat(options.step);
+        this.offset                 = Number.parseFloat(options.offset);
+        this.roundX                 = Boolean(options.roundX);
+        this.roundY                 = Boolean(options.roundY);
+        this.roundZ                 = Boolean(options.roundZ);
+
+        this.selectionBoundaries    = (options.selectionBoundaries !== undefined) ? options.selectionBoundaries : null;
+        this.useHistory             = false;
+
+        if(typeof gtag === 'function')
+        {
+            gtag('event', 'RoundTranslation', {event_category: 'Selection'});
+        }
+
+        this.round();
+    }
+
+    round()
+    {
+        if (
+            this.markers &&
+            Number.isFinite(this.offset) &&
+            Number.isFinite(this.step) &&
+            (this.roundX || this.roundY || this.roundZ))
+        {
+            console.time('roundTranslationMultipleMarkers');
+            let wires           = [];
+
+            for(let i = 0; i < this.markers.length; i++)
+            {
+                if(this.markers[i].options.pathName !== undefined)
+                {
+                    let currentObject = this.baseLayout.saveGameParser.getTargetObject(this.markers[i].options.pathName);
+
+                    if(currentObject !== null)
+                    {
+                        switch(currentObject.className)
+                        {
+                            case '/Game/FactoryGame/Character/Player/BP_PlayerState.BP_PlayerState_C':
+                                // Find target
+                                let mOwnedPawn = this.baseLayout.getObjectProperty(currentObject, 'mOwnedPawn');
+                                    if(mOwnedPawn !== null)
+                                    {
+                                        let currentObjectTarget = this.baseLayout.saveGameParser.getTargetObject(mOwnedPawn.pathName);
+                                        if(currentObjectTarget !== null)
+                                        {
+                                            this.roundTranslation(currentObjectTarget.transform.translation);
+                                        }
+                                    }
+                                break;
+                            case '/Game/FactoryGame/Buildable/Factory/TradingPost/Build_TradingPost.Build_TradingPost_C':
+                                // HUB should also move hidden objects
+                                let mHubTerminal = this.baseLayout.getObjectProperty(currentObject, 'mHubTerminal');
+                                    if(mHubTerminal !== null)
+                                    {
+                                        let currentObjectTarget = this.baseLayout.saveGameParser.getTargetObject(mHubTerminal.pathName);
+                                        if(currentObjectTarget !== null)
+                                        {
+                                            this.roundTranslation(currentObjectTarget.transform.translation);
+                                        }
+                                    }
+                                let mWorkBench = this.baseLayout.getObjectProperty(currentObject, 'mWorkBench');
+                                    if(mWorkBench !== null)
+                                    {
+                                        let currentObjectTarget = this.baseLayout.saveGameParser.getTargetObject(mWorkBench.pathName);
+                                        if(currentObjectTarget !== null)
+                                        {
+                                            this.roundTranslation(currentObjectTarget.transform.translation);
+                                        }
+                                    }
+                            default:
+                                this.roundTranslation(currentObject.transform.translation);
+                                break;
+                        }
+
+                        if(currentObject.children !== undefined)
+                        {
+                            for(let j = 0; j < currentObject.children.length; j++)
+                            {
+                                let currentObjectChildren = this.baseLayout.saveGameParser.getTargetObject(currentObject.children[j].pathName);
+                                    if(currentObjectChildren !== null)
+                                    {
+                                        // Grab wires for redraw...
+                                        for(let k = 0; k < this.baseLayout.availablePowerConnection.length; k++)
+                                        {
+                                            if(currentObjectChildren.pathName.endsWith(this.baseLayout.availablePowerConnection[k]))
+                                            {
+                                                for(let m = 0; m < currentObjectChildren.properties.length; m++)
+                                                {
+                                                    if(currentObjectChildren.properties[m].name === 'mWires')
+                                                    {
+                                                        for(let n = 0; n < currentObjectChildren.properties[m].value.values.length; n++)
+                                                        {
+                                                            if(wires.includes(currentObjectChildren.properties[m].value.values[n].pathName) === false)
+                                                            {
+                                                                wires.push(currentObjectChildren.properties[m].value.values[n].pathName);
+                                                            }
+                                                        }
+
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                            }
+                        }
+
+                        // Delete and add again!
+                        let result = this.baseLayout.parseObject(currentObject);
+                        this.baseLayout.deleteMarkerFromElements(result.layer, this.markers[i], true);
+                        this.baseLayout.addElementToLayer(result.layer, result.marker);
+                    }
+                }
+            }
+
+            for(let i = 0; i < wires.length; i++)
+            {
+                let currentObject   = this.baseLayout.saveGameParser.getTargetObject(wires[i]);
+                let result          = this.baseLayout.parseObject(currentObject);
+                let oldMarker       = this.baseLayout.getMarkerFromPathName(currentObject.pathName, result.layer);
+                this.baseLayout.deleteMarkerFromElements(result.layer, oldMarker, true);
+                this.baseLayout.addElementToLayer(result.layer, result.marker);
+            }
+
+            console.timeEnd('roundTranslationMultipleMarkers');
+            this.baseLayout.updateRadioactivityLayer();
+        }
+
+        Modal_Selection.cancel(this.baseLayout);
+    }
+
+    roundTranslation(translation) {
+        if (this.roundX) {
+            translation[0] = Math.round(translation[0] / this.step) * this.step - (Math.sign(translation[0]) * this.offset);
+        }
+        if (this.roundY) {
+            translation[1] = Math.round(translation[1] / this.step) * this.step - (Math.sign(translation[1]) * this.offset);
+        }
+        if (this.roundZ) {
+            translation[2] = Math.round(translation[2] / this.step) * this.step - (Math.sign(translation[2]) * this.offset);
+        }
+    }
+}


### PR DESCRIPTION
This allows for people like me who want things to be aligned perfectly to be able to achieve just that.

Note: This feature is currently only useful for things aligned to NSWE.

This will probably need to be reworked before it is universal enough to be added. I've got plans on how to do this but will require a lot of other work with in the code base first.

~~This can be used to satisfy #147 when setting the `step` size to `800` and applying it only to the x and y axises (This should only be done to foundations).~~ Thinking about it, this doesn't quite do what that issue requests.