### PR TITLE
refactor: use private fields and methods for SaveParser_Read

### DIFF
--- a/src/SaveParser/Read.js
+++ b/src/SaveParser/Read.js
@@ -1,21 +1,64 @@
 /* global Sentry, Intl, self */
+
+/**
+ * @typedef {import("./types").Header} Header
+ * @typedef {import("./types").SaveResult} SaveResult
+ * @typedef {import("./types").DefaultValues} DefaultValues
+ * @typedef {import("./types").ParsedByte} ParsedByte
+ * @typedef {import("./types").ParsedDouble} ParsedDouble
+ * @typedef {import("./types").ParsedFloat} ParsedFloat
+ * @typedef {import("./types").ParsedHex} ParsedHex
+ * @typedef {import("./types").ParsedInt} ParsedInt
+ * @typedef {import("./types").ParsedInt8} ParsedInt8
+ * @typedef {import("./types").ParsedLong} ParsedLong
+ * @typedef {import("./types").ParsedString} ParsedString
+ * @typedef {import("./types").ParsedFINGPUT1BufferPixel} ParsedFINGPUT1BufferPixel
+ */
+
 import pako                                     from '../Lib/pako.esm.mjs';
 
 export default class SaveParser_Read
 {
+    /** @type {ArrayBuffer} */
     #arrayBuffer;
+
+    /** @type {DataView} */
     #bufferView;
+
+    /** @type {number} */
     #currentByte;
+
+    /** @type {Uint8Array[]} */
     #currentChunks;
+
+    /** @type {DefaultValues} */
     #defaultValues;
+
+    /** @type {number} */
     #handledByte;
+
+    /** @type {Header} */
     #header;
+
+    /** @type {string} */
     #language;
+
+    /** @type {number} */
     #lastStrRead;
+
+    /** @type {number} */
     #maxByte;
+
+    /** @type {SaveResult} */
     #saveResult;
+
+    /** @type {Window} */
     #worker;
 
+    /**
+     * @param {Window} worker
+     * @param {{arrayBuffer: ArrayBuffer;defaultValues: DefaultValues; language: string;}} options
+     */
     constructor(worker, options)
     {
         this.#worker             = worker;
@@ -1312,10 +1355,14 @@ export default class SaveParser_Read
     {
         this.#currentByte += byteLength;
     }
+
+    /** @returns {ParsedByte} */
     #readByte()
     {
         return parseInt(this.#bufferView.getUint8(this.#currentByte++, true));
     }
+
+    /** @returns {ParsedHex} */
     #readHex(hexLength)
     {
         let hexPart = [];
@@ -1330,17 +1377,22 @@ export default class SaveParser_Read
         return hexPart.join('');
     }
 
+    /** @returns {ParsedInt8} */
     #readInt8()
     {
         let data = this.#bufferView.getInt8(this.#currentByte++, true);
             return data;
     }
+
+    /** @returns {ParsedInt} */
     #readInt()
     {
         let data = this.#bufferView.getInt32(this.#currentByte, true);
             this.#currentByte += 4;
             return data;
     }
+
+    /** @returns {ParsedLong} */
     #readLong()
     {
         let data1   = this.#readInt();
@@ -1356,12 +1408,15 @@ export default class SaveParser_Read
             }
     }
 
+    /** @returns {ParsedFloat} */
     #readFloat()
     {
         let data = this.#bufferView.getFloat32(this.#currentByte, true);
             this.#currentByte += 4;
             return data;
     }
+
+    /** @returns {ParsedDouble} */
     #readDouble()
     {
         let data = this.#bufferView.getFloat64(this.#currentByte, true);
@@ -1369,6 +1424,7 @@ export default class SaveParser_Read
             return data;
     }
 
+    /** @returns {ParsedString} */
     #readString()
     {
         let strLength       = this.#readInt();
@@ -1439,6 +1495,7 @@ export default class SaveParser_Read
         return;
     }
 
+    /** @returns {ParsedFINGPUT1BufferPixel} */
     #readFINGPUT1BufferPixel()
     {
         return {

--- a/src/SaveParser/types.d.ts
+++ b/src/SaveParser/types.d.ts
@@ -1,0 +1,95 @@
+export type Header = HeaderV7 | HeaderV8;
+
+type HeaderV7 = {
+  saveHeaderType: ParsedInt;
+  saveVersion: ParsedInt;
+  buildVersion: ParsedInt;
+  mapName: ParsedString;
+  mapOptions: ParsedString;
+  sessionName: ParsedString;
+  playDurationSeconds: ParsedInt;
+  saveDateTime: ParsedLong;
+  sessionVisibility: ParsedByte;
+  fEditorObjectVersion: ParsedInt;
+};
+
+type HeaderV8 = HeaderV7 & {
+  modMetadata: ParsedString;
+  isModdedSave: ParsedInt;
+};
+
+export type SaveResult = {
+  PACKAGE_FILE_TAG: number;
+  maxChunkSize: number;
+  objects: Record<GameObject["pathName"], GameObject>;
+  collectables: GameObjectProperty[];
+  gameStatePathName: GameObject["pathName"];
+  playerHostPathName: GameObject["pathName"];
+};
+
+export type DefaultValues = Readonly<{
+  rotation: [number, number, number, number];
+  translation: [number, number, number];
+  mPrimaryColor: {
+    name: string;
+    type: string;
+    value: {
+      type: string;
+      values: {
+        a: number;
+        b: number;
+        g: number;
+        r: number;
+      };
+    };
+  };
+  mSecondaryColor: {
+    name: string;
+    type: string;
+    value: {
+      type: string;
+      values: {
+        a: number;
+        b: number;
+        g: number;
+        r: number;
+      };
+    };
+  };
+}>;
+
+export type ParsedByte = number;
+
+export type ParsedDouble = number;
+
+export type ParsedFloat = number;
+
+export type ParsedHex = string;
+
+export type ParsedInt = number;
+
+export type ParsedInt8 = number;
+
+export type ParsedLong = number | [number, number];
+
+export type ParsedString = string;
+
+export type ParsedFINGPUT1BufferPixel = {
+  character: ParsedHex;
+  foregroundColor: {
+    r: ParsedFloat;
+    g: ParsedFloat;
+    b: ParsedFloat;
+    a: ParsedFloat;
+  };
+  backgroundColor: {
+    r: ParsedFloat;
+    g: ParsedFloat;
+    b: ParsedFloat;
+    a: ParsedFloat;
+  };
+};
+
+// TODO: these types properly.
+type GameObject = Record<string, any>;
+type GameObjectProperty = Record<string, any>;


### PR DESCRIPTION
This looks like a big change but all it is going it renaming fields and methods.
It simple prefixes each private method and field (which in this case is all of them) with "#".

Re: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields

It also adds types via JSDoc comments and the .d.ts file.