### PR TITLE
refactor: separate the read worker's logic from the worker itself

### DIFF
--- a/src/SCIM.js
+++ b/src/SCIM.js
@@ -24,7 +24,7 @@ export default class SCIM
         this.tetrominoUrl               = "https://satisfactory-calculator.com/" + this.language + "/api/tetromino";
         this.usersUrl                   = "https://satisfactory-calculator.com/" + this.language + "/api/users";
 
-        this.saveParserReadWorker       = '/js/InteractiveMap/build/Worker/SaveParser/Read.js';
+        this.saveParserReadWorker       = '/js/InteractiveMap/build/Worker/SaveParser/ReadWorker.js';
         this.saveParserWriteWorker      = '/js/InteractiveMap/build/Worker/SaveParser/Write.js';
 
         this.collectedOpacity           = 0.3;

--- a/src/SaveParser/Read.js
+++ b/src/SaveParser/Read.js
@@ -1,7 +1,11 @@
 /* global Sentry, Intl, self */
 import pako                                     from '../Lib/pako.esm.mjs';
 
-export default class SaveParser_Read
+export function parse(window, options) {
+    new SaveParser_Read(window, options);
+}
+
+class SaveParser_Read
 {
     constructor(worker, options)
     {
@@ -1558,8 +1562,4 @@ export default class SaveParser_Read
 
         return data;
     }
-};
-
-self.onmessage = function(e){
-    return new SaveParser_Read(self, e.data);
 };

--- a/src/SaveParser/ReadWorker.js
+++ b/src/SaveParser/ReadWorker.js
@@ -1,0 +1,5 @@
+import { parse } from "./Read.js"
+
+self.onmessage = (e) => {
+    parse(self, e.data);
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
         context         : path.resolve(__dirname, 'src'),
         entry           : {
             SCIM                        : './SCIM.js',
-            'Worker/SaveParser/Read'    : './SaveParser/Read.js',
+            'Worker/SaveParser/Read'    : './SaveParser/ReadWorker.js',
             'Worker/SaveParser/Write'   : './SaveParser/Write.js'
         },
 

--- a/webpack.experimental.config.js
+++ b/webpack.experimental.config.js
@@ -16,7 +16,7 @@ module.exports = env => {
         context         : path.resolve(__dirname, 'src'),
         entry           : {
             SCIM                        : './SCIM.js',
-            'Worker/SaveParser/Read'    : './SaveParser/Read.js',
+            'Worker/SaveParser/Read'    : './SaveParser/ReadWorker.js',
             'Worker/SaveParser/Write'   : './SaveParser/Write.js'
         },
 


### PR DESCRIPTION
This will allow for load the parsing logic from other files without the side effect of setting `self.onmessage`.