### PR TITLE
refactor: move the default values out of the SaveParser class

### DIFF
--- a/src/SaveParser.js
+++ b/src/SaveParser.js
@@ -22,39 +22,6 @@ export default class SaveParser
 
         this.gameStatePathName      = null;
         this.playerHostPathName     = null;
-
-        // Holds some default values to reduce memory usage...
-        this.defaultValues          = {
-            rotation                    : [0, 0, 0, 1],
-            translation                 : [0, 0, 0],
-
-            mPrimaryColor               : {
-                name: "mPrimaryColor",
-                type: "StructProperty",
-                value: {
-                    type: "LinearColor",
-                    values: {
-                        a: 1,
-                        b: 0.15631400048732758,
-                        g: 0.44070500135421753,
-                        r: 1
-                    }
-                }
-            },
-            mSecondaryColor             : {
-                name: "mSecondaryColor",
-                type: "StructProperty",
-                value: {
-                    type: "LinearColor",
-                    values: {
-                        a: 1,
-                        b: 0.26225098967552185,
-                        g: 0.13286800682544708,
-                        r: 0.11697100102901459
-                    }
-                }
-            }
-        };
     }
 
     load(callback = null)
@@ -69,7 +36,6 @@ export default class SaveParser
         this.worker.onmessage   = function(e){ this.onWorkerMessage(e.data); }.bind(this);
         this.worker.postMessage({
             arrayBuffer     : this.arrayBuffer,
-            defaultValues   : this.defaultValues,
             language        : this.language
         });
 
@@ -91,7 +57,6 @@ export default class SaveParser
             this.worker             = new Worker(this.workers.SaveParserWrite, { type: "module" });
             this.worker.onmessage   = function(e){ this.onWorkerMessage(e.data); }.bind(this);
             this.worker.postMessage({
-                defaultValues       : this.defaultValues,
                 language            : this.language,
 
                 header              : this.header,
@@ -255,3 +220,36 @@ export default class SaveParser
             }
     }
 }
+
+// Holds some default values to reduce memory usage...
+export const defaultValues = {
+    rotation: [0, 0, 0, 1],
+    translation: [0, 0, 0],
+
+    mPrimaryColor: {
+        name: "mPrimaryColor",
+        type: "StructProperty",
+        value: {
+            type: "LinearColor",
+            values: {
+                a: 1,
+                b: 0.15631400048732758,
+                g: 0.44070500135421753,
+                r: 1
+            }
+        }
+    },
+    mSecondaryColor: {
+        name: "mSecondaryColor",
+        type: "StructProperty",
+        value: {
+            type: "LinearColor",
+            values: {
+                a: 1,
+                b: 0.26225098967552185,
+                g: 0.13286800682544708,
+                r: 0.11697100102901459
+            }
+        }
+    }
+};

--- a/src/SaveParser/Read.js
+++ b/src/SaveParser/Read.js
@@ -1,6 +1,8 @@
 /* global Sentry, Intl, self */
 import pako                                     from '../Lib/pako.esm.mjs';
 
+import { defaultValues }                        from '../SaveParser.js'
+
 export default class SaveParser_Read
 {
     constructor(worker, options)
@@ -9,7 +11,6 @@ export default class SaveParser_Read
         this.saveResult         = {};
         this.saveResult.objects = {};
 
-        this.defaultValues      = options.defaultValues;
         this.language           = options.language;
 
         this.arrayBuffer        = options.arrayBuffer;
@@ -250,13 +251,13 @@ export default class SaveParser_Read
             actor.transform     = {};
 
             if(
-                    rotation[0] === this.defaultValues.rotation[0]
-                 && rotation[1] === this.defaultValues.rotation[1]
-                 && rotation[2] === this.defaultValues.rotation[2]
-                 && rotation[3] === this.defaultValues.rotation[3]
+                    rotation[0] === defaultValues.rotation[0]
+                 && rotation[1] === defaultValues.rotation[1]
+                 && rotation[2] === defaultValues.rotation[2]
+                 && rotation[3] === defaultValues.rotation[3]
             )
             {
-                actor.transform.rotation    = this.defaultValues.rotation;
+                actor.transform.rotation    = defaultValues.rotation;
             }
             else
             {
@@ -264,12 +265,12 @@ export default class SaveParser_Read
             }
 
             if(
-                    translation[0] === this.defaultValues.translation[0]
-                 && translation[1] === this.defaultValues.translation[1]
-                 && translation[2] === this.defaultValues.translation[2]
+                    translation[0] === defaultValues.translation[0]
+                 && translation[1] === defaultValues.translation[1]
+                 && translation[2] === defaultValues.translation[2]
             )
             {
-                actor.transform.translation = this.defaultValues.translation;
+                actor.transform.translation = defaultValues.translation;
             }
             else
             {
@@ -993,13 +994,13 @@ export default class SaveParser_Read
                         if(currentProperty.name === 'mPrimaryColor' || currentProperty.name === 'mSecondaryColor')
                         {
                             if(
-                                   currentProperty.value.values.r === this.defaultValues[currentProperty.name].value.values.r
-                                && currentProperty.value.values.g === this.defaultValues[currentProperty.name].value.values.g
-                                && currentProperty.value.values.b === this.defaultValues[currentProperty.name].value.values.b
-                                && currentProperty.value.values.a === this.defaultValues[currentProperty.name].value.values.a
+                                   currentProperty.value.values.r === defaultValues[currentProperty.name].value.values.r
+                                && currentProperty.value.values.g === defaultValues[currentProperty.name].value.values.g
+                                && currentProperty.value.values.b === defaultValues[currentProperty.name].value.values.b
+                                && currentProperty.value.values.a === defaultValues[currentProperty.name].value.values.a
                             )
                             {
-                                currentProperty = this.defaultValues[currentProperty.name];
+                                currentProperty = defaultValues[currentProperty.name];
                             }
                         }
 

--- a/src/Spawn/Fill.js
+++ b/src/Spawn/Fill.js
@@ -4,6 +4,8 @@ import BaseLayout_Modal                         from '../BaseLayout/Modal.js';
 
 import Modal_Selection                          from '../Modal/Selection.js';
 
+import { defaultValues }                        from '../SaveParser.js'
+
 export default class Spawn_Fill
 {
     constructor(options)
@@ -60,7 +62,7 @@ export default class Spawn_Fill
             pathName        : 'Persistent_Level:PersistentLevel.' + extractPathName + '_XXX',
             needTransform   : 1,
             transform       : {
-                rotation        : this.baseLayout.saveGameParser.defaultValues.rotation,
+                rotation        : defaultValues.rotation,
                 translation     : this.center
             },
             entity          : {pathName: "Persistent_Level:PersistentLevel.BuildableSubsystem"},


### PR DESCRIPTION
Make it so we don't have to pass it around to all the places that need it, they can just import it.

This will also help make future refactoring easier.