### PR TITLE
Add a button to the minimap to export the current view as an image (#219)

### DIFF
--- a/src/GameMap.js
+++ b/src/GameMap.js
@@ -233,7 +233,8 @@ export default class GameMap
             noWrap              : true,
             bounds              : this.getBounds(),
             maxZoom             : (this.maxTileZoom + 4),
-            maxNativeZoom       : this.maxTileZoom
+            maxNativeZoom       : this.maxTileZoom,
+            crossOrigin         : true,
         };
 
         this.baseLayer                  = 'gameLayer';
@@ -243,6 +244,9 @@ export default class GameMap
         // Constrain map
         this.leafletMap.setMaxBounds(this.getBounds());
         this.leafletMap.fitBounds(this.getBounds());
+
+        this.exportControl = L.control.exportControl({});
+        this.leafletMap.addControl(this.exportControl);
 
         // Trigger initial hash to load previous layers...
         this.formatHash();

--- a/src/GameMap.js
+++ b/src/GameMap.js
@@ -234,7 +234,7 @@ export default class GameMap
             bounds              : this.getBounds(),
             maxZoom             : (this.maxTileZoom + 4),
             maxNativeZoom       : this.maxTileZoom,
-            crossOrigin         : true,
+            crossOrigin         : true,    // We need this in order to be able to render tiles to a canvas.  Otherwise, we'd need to re-fetch all the tiles.
         };
 
         this.baseLayer                  = 'gameLayer';
@@ -245,6 +245,7 @@ export default class GameMap
         this.leafletMap.setMaxBounds(this.getBounds());
         this.leafletMap.fitBounds(this.getBounds());
 
+        // Add a button to export the current viewport as an image and then download it.
         this.exportControl = L.control.exportControl({});
         this.leafletMap.addControl(this.exportControl);
 

--- a/src/SCIM.js
+++ b/src/SCIM.js
@@ -1,3 +1,4 @@
+/* global L */
 import BaseLayout                               from './BaseLayout.js';
 import GameMap                                  from './GameMap.js';
 import SaveParser                               from './SaveParser.js';
@@ -5,6 +6,7 @@ import Translate                                from './Translate.js';
 
 import BaseLayout_Modal                         from './BaseLayout/Modal.js';
 import Lib_LeafletPlugins                       from './Lib/LeafletPlugins.js';
+import saveAs                                   from './Lib/FileSaver.js';
 
 export default class SCIM
 {
@@ -226,5 +228,63 @@ export default class SCIM
 
         return true;
     };
+
+    // Export map as image
+    exportImage() {
+        // no map?
+        if (!this.map) {
+            return null;
+        }
+        let imageName = 'export.png';
+        if (this.baseLayout && this.baseLayout.saveGameParser) {
+            imageName = this.baseLayout.saveGameParser.fileName.replace(/\.sav$/g, '.png');
+        }
+
+        this.map.leafletMap.renderToCanvas((err, canvas) => {
+            if (err) {
+                return console.error(err);
+            }
+
+            if (canvas.toBlob) {
+                return canvas.toBlob((blob) => {
+                    if (!blob) {
+                        console.error('Failed to render to canvas for some reason...');
+                    } else {
+                        saveAs(blob, imageName);
+                    }
+                });
+            } else {
+                const dataURL = canvas.toDataURL();
+                if (!dataURL) {
+                    console.error('Could not get data url from canvas!');
+                }
+
+                const BASE64_MARKER = ';base64,';
+                let blob;
+                if (dataURL.indexOf(BASE64_MARKER) == -1) {
+                    const parts = dataURL.split(',');
+                    const contentType = parts[0].split(':')[1];
+                    const raw = decodeURIComponent(parts[1]);
+
+                    blob = new Blob([raw], {type: contentType});
+                } else {
+                    const parts = dataURL.split(BASE64_MARKER);
+                    const contentType = parts[0].split(':')[1];
+                    const raw = window.atob(parts[1]);
+                    const rawLength = raw.length;
+
+                    const uInt8Array = new Uint8Array(rawLength);
+
+                    for (let i = 0; i < rawLength; ++i) {
+                        uInt8Array[i] = raw.charCodeAt(i);
+                    }
+
+                    blob = new Blob([uInt8Array], {type: contentType});
+                }
+
+                saveAs(blob, imageName);
+            }
+        });
+    }
 }
 window.SCIM = new SCIM();

--- a/src/SCIM.js
+++ b/src/SCIM.js
@@ -1,4 +1,3 @@
-/* global L */
 import BaseLayout                               from './BaseLayout.js';
 import GameMap                                  from './GameMap.js';
 import SaveParser                               from './SaveParser.js';
@@ -229,7 +228,12 @@ export default class SCIM
         return true;
     };
 
-    // Export map as image
+    /**
+     * Export the current viewport as a png.  If there is a save game loaded, this png will have the same name as the save game file.
+     * If not, it will be named `export.png`
+     * @async
+     * @returns {void}
+     */
     exportImage() {
         // no map?
         if (!this.map) {


### PR DESCRIPTION
This contains what's essentially a rewrite of the `leaflet-image` plugin.  That plugin mostly worked, but didn't handle fractional zooms and some of the transforms that (newer versions of?) `Leaflet` uses.

Note that this only exports the map tile layer and the overlay layer.  Markers are not exported.  They're html markers that contain `svg` elements, which don't seem to be easy to render to a canvas.  I can probably figure out how to include them in the future, but this seemed like a good start.

- Extends `TileLayer` to provide the ability to render to a canvas
- Extends `Map` to composite any tile layers and overlays as canvases
- Add a control that uses `map.exportToCanvas` to get an canvas representation of the current viewport.  This will save as `export.png` when no save is loaded, or as `<save name>.png` if there is a save
  - This is a little janky at the moment, and could probably be improved somewhat.  The only thing that has knowledge of both the map and the save game is the global `SCIM` object, which seems strange to access from a control installed by `GameMap`

This addresses the core functionality of #219.  There's a lot more I could do here to enable automation of multiple save games, etc, but I figured this was a good starting point.

A screenshot (captured with the OS screenshot tool) of the test map with some random zooms/pans applied after loading:

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/3535453/169677670-396c222e-8e3e-401d-a366-387fd6e0078e.png">

Note the new button!

The exported image of the same viewport, created by clicking the new button:

![CREATIVE TEST](https://user-images.githubusercontent.com/3535453/169677687-16555f6b-4ee0-4b8d-a3e0-a64600cd7212.png)

Note about the above images: I captured the first screenshot on a Mac with a retina display, so it's "upscaled" .  The display size of both images is actually identical on the device itself.