### PR TITLE
updating issue templates post-release of Update 6

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Feature Requests not relating to Update 6
+about: Feature Requests & improvements to the Interactive Map
 labels: 'enhancement'
 title: ''
 

--- a/.github/ISSUE_TEMPLATE/update6_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/update6_feature_request.md
@@ -1,7 +1,0 @@
----
-name: Update 6 Feature Request
-about: Feature Requests relating to any changes announced for Satisfactory Update 6
-labels: 'enhancement, Update 6'
-title: ''
-
----


### PR DESCRIPTION
follow-up to #223 

Removed Update 6 template, no EX release of Update 7 so no new template added.