### PR TITLE
Use TextDecoder for improved save file load performance

### DIFF
--- a/src/SaveParser/Read.js
+++ b/src/SaveParser/Read.js
@@ -21,6 +21,9 @@ export default class SaveParser_Read
         this.isDegraded             = false;
         this.degradedMaxRangeLength = 2145386496;
 
+        this.utf8Decoder = new TextDecoder('utf-8');
+        this.utf16Decoder = new TextDecoder('utf-16le');
+
         this.parseSave();
     }
 
@@ -2336,9 +2339,8 @@ export default class SaveParser_Read
         {
             strLength = -strLength - 1;
             // Use Uint16Array and TextDecoder for UTF-16LE
-            const decoder = new TextDecoder('utf-16le');
             const bytes = new Uint8Array(this.bufferView.buffer, this.currentByte, strLength * 2);
-            const string = decoder.decode(bytes);
+            const string = this.utf16Decoder.decode(bytes);
             this.currentByte += strLength * 2 + 2; // +2 for null terminator
             return string;
         }
@@ -2347,9 +2349,8 @@ export default class SaveParser_Read
         {
             strLength = strLength - 1;
             // Use Uint8Array and TextDecoder for UTF-8
-            const decoder = new TextDecoder('utf-8');
             const bytes = new Uint8Array(this.bufferView.buffer, this.currentByte, strLength);
-            const string = decoder.decode(bytes);
+            const string = this.utf8Decoder.decode(bytes);
             this.currentByte += strLength + 1; // +1 for null terminator
 
             return string;

--- a/src/SaveParser/Read.js
+++ b/src/SaveParser/Read.js
@@ -2334,37 +2334,25 @@ export default class SaveParser_Read
         // UTF16
         if(strLength < 0)
         {
-                strLength   = -strLength - 1;
-            let string      = [];
-
-            for(let i = 0; i < strLength; ++i)
-            {
-                let caracter = String.fromCharCode(
-                        this.bufferView.getUint16(this.currentByte++, true)
-                    );
-                    string.push(caracter);
-                    this.currentByte++;
-            }
-            this.currentByte++;
-            this.currentByte++;
-
-            return string.join('');
+            strLength = -strLength - 1;
+            // Use Uint16Array and TextDecoder for UTF-16LE
+            const decoder = new TextDecoder('utf-16le');
+            const bytes = new Uint8Array(this.bufferView.buffer, this.currentByte, strLength * 2);
+            const string = decoder.decode(bytes);
+            this.currentByte += strLength * 2 + 2; // +2 for null terminator
+            return string;
         }
 
         try
         {
-                strLength   = strLength -1;
-            let string      = [];
+            strLength = strLength - 1;
+            // Use Uint8Array and TextDecoder for UTF-8
+            const decoder = new TextDecoder('utf-8');
+            const bytes = new Uint8Array(this.bufferView.buffer, this.currentByte, strLength);
+            const string = decoder.decode(bytes);
+            this.currentByte += strLength + 1; // +1 for null terminator
 
-            for(let i = 0; i < strLength; i++)
-            {
-                string.push(String.fromCharCode(
-                    this.bufferView.getUint8(this.currentByte++, true)
-                ));
-            }
-            this.currentByte++;
-
-            return string.join('');
+            return string;
         }
         catch(error)
         {


### PR DESCRIPTION
After doing some profiling in chrome, I noticed that readString was the biggest use of CPU time when loading a large save file. I looked at ways to optimize this function, and went with TextDecoder to see if it would improve.

The result from my benchmark tests (using vitest, in node environment) is a big improvement boost, making saves load around 36% faster.

Note: I haven't tested this in the browser or checked if the final output is correct. I can look into doing that if necessary.

### Performance test results for loading the example file (CREATIVE TEST.sav):

**Before Changes**
```
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parse save file Original  1.5334  627.12  676.17  652.16  665.02  676.17  676.17  676.17  ±1.89%       10
```

Loaded 8930 objects...: 58.528ms
Loaded 8930 entities...: 333.521ms
Total: 675.676ms

**With changes**
```
    name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parse save file Updated  2.4355  392.59  430.06  410.59  415.60  430.06  430.06  430.06  ±2.04%       10
```
objects...: 17.073ms
Loaded 8930 entities...: 169.508ms
Total2: 377.759ms

### Performance test with my larger save file

**Before**

```
     name                          hz       min       max      mean       p75       p99      p995      p999     rme  samples
   · parse save file Original  0.2102  4,608.38  4,909.83  4,756.88  4,822.78  4,909.83  4,909.83  4,909.83  ±1.41%       10

// example logs
Loaded 106475 objects...: 762.363ms
Loaded 106475 entities...: 2.756s
Total: 4.840s
```

**After**

```
     name                         hz       min       max      mean       p75       p99      p995      p999     rme  samples
   · parse save file Updated  0.3682  2,638.23  2,799.48  2,715.76  2,746.70  2,799.48  2,799.48  2,799.48  ±1.30%       10

// example logs
Loaded 106475 objects...: 219.63ms
Loaded 106475 entities...: 1.310s
Total2: 2.746s

```


### Test/ benchmark file used :

Read2.bench.js
```
import { bench, describe  } from "vitest";
import Read2 from "./Read";
import { readFileSync } from "fs";
import { join } from "path";

const file = readFileSync(join(__dirname, "../../CREATIVE TEST.sav")).buffer;

describe("Read2", () => {
    bench('parse save file Updated', () => {
        console.time("Total2");
        const read = new Read2(
            { postMessage: (...args) => {} }, // Mock implementation of worker to simplify benchmark
            {
                arrayBuffer: file,
                language: 'en-US'
            }
        );
        console.timeEnd("Total2");
    })
});

```