### PR TITLE
Optimise getItemDataFromClassName and map hash throttle

### DIFF
--- a/src/BaseLayout.js
+++ b/src/BaseLayout.js
@@ -107,6 +107,7 @@ export default class BaseLayout
         this.buildingsData                      = null;
         this.buildingsCategories                = {};
         this.itemsData                          = null;
+        this.itemClassNames                     = {};
         this.itemsCategories                    = {};
         this.toolsData                          = null;
         this.toolsCategories                    = {};
@@ -424,12 +425,23 @@ export default class BaseLayout
                         this.modsData               = data.modsData;
 
                         this.loadDetailedModels();
+                        this.cacheItemIds();
                     });
                 });
             }
             else
             {
                 this.loadDetailedModels();
+            }
+        });
+    }
+
+    cacheItemIds() {
+        this.itemClassNames = {};
+        Object.entries(this.itemsData).forEach(([itemId, itemData]) => {
+            if(itemData.className)
+            {
+                this.itemClassNames[itemData.className] = itemId;
             }
         });
     }
@@ -4592,12 +4604,11 @@ export default class BaseLayout
             this.itemsData[className].id = className;
             return this.itemsData[className];
         }
-        for(let i in this.itemsData)
-        {
-            if(this.itemsData[i].className !== undefined && this.itemsData[i].className === className)
-            {
-                this.itemsData[i].id = i;
-                return this.itemsData[i];
+        if (this.itemClassNames[className] !== undefined) {
+            const itemId = this.itemClassNames[className];
+            if (this.itemsData[itemId] !== undefined) {
+                this.itemsData[itemId].id = itemId;
+                return this.itemsData[itemId];
             }
         }
         if(this.toolsData[className] !== undefined)

--- a/src/GameMap.js
+++ b/src/GameMap.js
@@ -435,9 +435,9 @@ export default class GameMap
     setupEvents()
     {
         // Hash
-        this.leafletMap.on("moveend", this._throttle(() => { return this.updateHash(); }, 100, {leading: true, trailing: true}), this);
-        this.leafletMap.on('layeradd', this._throttle(() => { return this.updateHash(); }, 100, {leading: true, trailing: true}), this);
-        this.leafletMap.on('layerremove', this._throttle(() => { return this.updateHash(); }, 100, {leading: true, trailing: true}), this);
+        this.leafletMap.on("moveend", this._throttle(() => { this.updateHash(); }, 100, {leading: true, trailing: true}), this);
+        this.leafletMap.on('layeradd', this._throttle(() => { this.updateHash(); }, 100, {leading: true, trailing: true}), this);
+        this.leafletMap.on('layerremove', this._throttle(() => { this.updateHash(); }, 100, {leading: true, trailing: true}), this);
 
         L.DomEvent.addListener(window, "hashchange", this._throttle(() => { return this.onHashChange(); }, 100, {leading: true, trailing: true}));
 

--- a/src/GameMap.js
+++ b/src/GameMap.js
@@ -435,9 +435,9 @@ export default class GameMap
     setupEvents()
     {
         // Hash
-        this.leafletMap.on("moveend", this.updateHash, this);
-        this.leafletMap.on('layeradd', this.updateHash, this);
-        this.leafletMap.on('layerremove', this.updateHash, this);
+        this.leafletMap.on("moveend", this._throttle(() => { return this.updateHash(); }, 100, {leading: true, trailing: true}), this);
+        this.leafletMap.on('layeradd', this._throttle(() => { return this.updateHash(); }, 100, {leading: true, trailing: true}), this);
+        this.leafletMap.on('layerremove', this._throttle(() => { return this.updateHash(); }, 100, {leading: true, trailing: true}), this);
 
         L.DomEvent.addListener(window, "hashchange", this._throttle(() => { return this.onHashChange(); }, 100, {leading: true, trailing: true}));
 


### PR DESCRIPTION
Optimise some functions that are called repeatedly when loading map objects.

I didn't really want to deep dive into more save file loading optimisation at the moment as there is quite a lot of logic in there, so these are just a couple of 'easy wins' at the moment.

Before Changes:
addMapLayers: 2634.0009765625 ms
addMapLayers: 2583.52880859375 ms


After Changes:
addMapLayers: 1786.555908203125 ms
addMapLayers: 1785.843017578125 ms